### PR TITLE
Handle missing 'total/up' devices metadata for RAID0 array configurat…

### DIFF
--- a/checks.d/md.py
+++ b/checks.d/md.py
@@ -72,11 +72,21 @@ class mdCheck(AgentCheck):
                         if dev:
                             mds_list[device_name]['active'].append(dev.group(1))
                             continue
-                # The next line should have some more array metadata.
-                detail = re.search('\[(\d+)\/(\d+)\]', f_mdstat.readline())
-                if detail:
-                    mds_list[device_name]['total'] = detail.group(1)
-                    mds_list[device_name]['up'] = detail.group(2)
+
+                # handle missing metadata for raid0 array configurations.
+                if raid_level == 'raid0':
+                    active_total = len(mds_list[device_name]['active'])
+                    failed_total = len(mds_list[device_name]['failed'])
+                    spare_total = len(mds_list[device_name]['spare'])
+                    total_devices = active_total + failed_total + spare_total
+                    mds_list[device_name]['total'] = total_devices
+                    mds_list[device_name]['up'] = active_total
+                else:
+                    # The next line should have some more array metadata.
+                    detail = re.search('\[(\d+)\/(\d+)\]', f_mdstat.readline())
+                    if detail:
+                        mds_list[device_name]['total'] = detail.group(1)
+                        mds_list[device_name]['up'] = detail.group(2)
 
                 # There may or may not be a next line if a recovery is happening.
                 mds_list[device_name]['recovery_speed'] = 0


### PR DESCRIPTION
…ions

This PR will fix the errors generated by the md check for disk instances configured with RAID0.
If an instance is setup for RAID0, the check will return a KeyError for 'total'(line #26) because the regular expression lookup fails to find a pattern matching [%d/%d] in /proc/mdstat for the instance. The C source files for the md driver (links provided below) indicate this string pattern is only found on devices configured with RAID1, RAID10, and RAID5 but not RAID0.

**Source Files:**
- RAID1: https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/tree/drivers/md/raid1.c?h=v2.6.32.5#n1003
- RAID10: https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/tree/drivers/md/raid10.c?h=v2.6.32.5#n999
- RAID5: https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/tree/drivers/md/raid5.c#n7068
